### PR TITLE
Install selinux utils for os family and version

### DIFF
--- a/tasks/debian.yaml
+++ b/tasks/debian.yaml
@@ -1,0 +1,30 @@
+# Always run including in check mode
+- name: selinux | check exists
+  stat:
+    path: /usr/sbin/getenforce
+  register: selinux_getenforce_st
+  check_mode: false
+
+- name: selinux | check enabled
+  become: true
+  command: /usr/sbin/getenforce
+  register: selinux_getenforce
+  check_mode: false
+  changed_when: false
+  when: selinux_getenforce_st.stat.exists
+
+- name: system packages | set selinux variable
+  set_fact:
+    selinux_enabled: >-
+      {{ selinux_getenforce_st.stat.exists and
+         selinux_getenforce.stdout != 'Disabled' }}
+
+- name: system packages | install selinux utilities
+  become: true
+  package:
+    name:
+      - libselinux-python
+      - libsemanage-python
+      - policycoreutils-python
+    state: present
+  when: selinux_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,33 +6,9 @@
 # missing: https://github.com/ansible/ansible/issues/16612
 # so use getenforce instead
 
-# Always run including in check mode
-- name: selinux | check exists
-  stat:
-    path: /usr/sbin/getenforce
-  register: selinux_getenforce_st
-  check_mode: false
+- import_tasks: redhat.yaml
+  when: ansible_os_family | lower == 'redhat'
 
-- name: selinux | check enabled
-  become: true
-  command: /usr/sbin/getenforce
-  register: selinux_getenforce
-  check_mode: false
-  changed_when: false
-  when: selinux_getenforce_st.stat.exists
+- import_tasks: debian.yaml
+  when: ansible_os_family | lower == 'debian'
 
-- name: system packages | set selinux variable
-  set_fact:
-    selinux_enabled: >-
-      {{ selinux_getenforce_st.stat.exists and
-         selinux_getenforce.stdout != 'Disabled' }}
-
-- name: system packages | install selinux utilities
-  become: true
-  package:
-    name:
-      - libselinux-python
-      - libsemanage-python
-      - policycoreutils-python
-    state: present
-  when: selinux_enabled

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -1,0 +1,40 @@
+# Always run including in check mode
+- name: selinux | check exists
+  stat:
+    path: /usr/sbin/getenforce
+  register: selinux_getenforce_st
+  check_mode: false
+
+- name: selinux | check enabled
+  become: true
+  command: /usr/sbin/getenforce
+  register: selinux_getenforce
+  check_mode: false
+  changed_when: false
+  when: selinux_getenforce_st.stat.exists
+
+- name: system packages | set selinux variable
+  set_fact:
+    selinux_enabled: >-
+      {{ selinux_getenforce_st.stat.exists and
+         selinux_getenforce.stdout != 'Disabled' }}
+
+- name: system packages | install selinux utilities
+  become: true
+  package:
+    name:
+      - libselinux-python
+      - libsemanage-python
+      - policycoreutils-python
+    state: present
+  when: selinux_enabled and ansible_facts['distribution_major_version'] == "7"
+
+- name: system packages | install selinux utilities
+  become: true
+  package:
+    name:
+      - python3-libselinux
+      - python3-libsemanage
+      - policycoreutils-python-utils
+    state: present
+  when: selinux_enabled and ansible_facts['distribution_major_version'] == "8"


### PR DESCRIPTION
Closes #1 

Splits the task according to OS family.

For `Redhat` family major version `7` installs:

```
 - libselinux-python
 - libsemanage-python
 - policycoreutils-python
 ```

And for major version `8` installs:

```
 - python3-libselinux
 - python3-libsemanage
 - policycoreutils-python-utils
 ```